### PR TITLE
fix(SagaTester): restore synchronous testability

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,3 +2,4 @@ export * from './interfaces';
 export * from './runner';
 export * from './util';
 export * from './middleware';
+export * from './scheduler';

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,0 +1,6 @@
+import {provide, Provider, OpaqueToken} from 'angular2/core';
+import { async } from 'rxjs/scheduler/async';
+
+export const SagaScheduler = new OpaqueToken('@ngrx/store/sagas Scheduler');
+
+export const schedulerProvider = provide(SagaScheduler, { useValue: async });

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,4 +1,3 @@
-import { asap } from 'rxjs/scheduler/asap';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { BehaviorSubject } from 'rxjs/subject/BehaviorSubject';
@@ -13,9 +12,9 @@ export class SagaTester extends SagaRunner{
 
   constructor(injector: Injector){
     const dispatcher = new BehaviorSubject(undefined);
-    super(injector, dispatcher, undefined, []);
 
-    this._scheduler = asap;
+    super(injector, dispatcher, undefined, undefined, []);
+
     this.output = dispatcher;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "lib/runner.ts",
     "lib/interfaces.ts",
     "lib/util.ts",
+    "lib/scheduler.ts",
 		"lib/testing.ts",
 		"lib/middleware.ts"
 	],


### PR DESCRIPTION
`.observeOn` has no notion of synchronous invocation.

I think there's potentially more we could do here, but these changes at least would restore SagaTester to its intended behavior.
