### PR TITLE
Stick rxjs to version 5.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "istanbul": "^0.4.2",
     "jasmine": "^2.4.1",
     "reflect-metadata": "^0.1.2",
-    "rxjs": "^5.0.0-beta.3",
+    "rxjs": "5.0.0-beta.4",
     "ts-node": "^0.5.5",
     "typescript": "^1.8.9",
     "typings": "^0.7.9"


### PR DESCRIPTION
In `rxjs@5.0.0-beta.5` the `BehaviorSubject` was moved to `rxjs/BehaviorSubject`. This pull request fixes this issue by sticking the version to the last working one.

Stack trace after checking out and running `npm test`.

```
lib/testing.ts(3,33): error TS2307: Cannot find module 'rxjs/subject/BehaviorSubject'.
node_modules/@ngrx/store/dist/store.d.ts(2,33): error TS2307: Cannot find module 'rxjs/subject/BehaviorSubject'.
node_modules/rxjs/Observable.d.ts(1,1): error TS2654: Exported external package typings file cannot contain tripleslash references. Please contact the package author to update the package definition.
```
