### PR TITLE
[doc] Rename saga, saga factory and iteration in docs ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Write a saga:
 import {createSaga} from 'store-saga';
 
 export const increment = createSaga(function(){
-  return saga$ => saga$
-    .filter(saga => saga.action.type === 'DECREMENT')
+  return iteration$ => iteration$
+    .filter(iter => iter.action.type === 'DECREMENT')
     .map(() => {
       return { type: 'INCREMENT'}
     });
@@ -121,10 +121,10 @@ export class LoginForm {
 Now we can write a saga that listens for the `AUTH_REQUESTED` action and makes the Http request. If the request succeeds, we will dispatch an `AUTH_SUCCESS` action and if the request fails we will dispatch an `AUTH_FAILURE` action:
 
 ```js
-const loginEffect = createSaga(function(http: Http) {
+const loginEffect = createSaga(function loginSagaFactory(http: Http) {
 
-  return function(saga$: Observable<any>) {
-    return saga$
+  return function loginSaga(iteration$: Observable<any>) {
+    return iteration$
       .filter(iteration => iteration.action.type === 'AUTH_REQUESTED')
       .map(iteration => iteration.action.payload)
       .mergeMap(payload => {


### PR DESCRIPTION
... so they match more closely their actual meaning from code. Just not to confuse (further) people approaching saga middleware. So that, e.g., a `saga` is the actual long-term transaction, so the function doing the processing, while the `sagaFactory` is what actually builds the saga, and `iteration` is a single turn of updates received from dispatched actions.

HTH, please feel free to comment or propose changes
